### PR TITLE
feat: `messageToSign` ignores data that are not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2020-11-26
+### Added
+- `generateSSORequestParams` throws on empty PK
+
+### Changed
+- join operator for `messageToSign` is now `&`
+- `messageToSign` ignores data that are not set (`null` or `undefined`)
+
+### Fixed
+- ensure testing `throws` is working correctly
+
 ## [0.3.1] - 2020-11-25
 ### Added
 - Logo and badges to README

--- a/DOCS.md
+++ b/DOCS.md
@@ -6,7 +6,7 @@
     * [.verifySilkeySignature](#module_SilkeySDK.verifySilkeySignature) ⇒ <code>null</code> \| <code>boolean</code>
     * [.fetchSilkeyPublicKey](#module_SilkeySDK.fetchSilkeyPublicKey) ⇒ <code>Promise.&lt;string&gt;</code>
     * [.messageToSign(data)](#module_SilkeySDK.messageToSign) ⇒ <code>string</code>
-    * [.generateSSORequestParams(privateKey, data)](#module_SilkeySDK.generateSSORequestParams) ⇒ <code>Object</code>
+    * [.generateSSORequestParams(privateKey, params)](#module_SilkeySDK.generateSSORequestParams) ⇒ <code>Object</code>
     * [.tokenPayloadVerifier(token, silkeyPublicKey)](#module_SilkeySDK.tokenPayloadVerifier) ⇒ <code>JwtPayload</code> \| <code>null</code>
 
 <a name="module_SilkeySDK.verifySilkeySignature"></a>
@@ -54,15 +54,19 @@ messageToSign({redirectUrl: 'http://silkey.io', refId: 1});
 ```
 <a name="module_SilkeySDK.generateSSORequestParams"></a>
 
-### SilkeySDK.generateSSORequestParams(privateKey, data) ⇒ <code>Object</code>
+### SilkeySDK.generateSSORequestParams(privateKey, params) ⇒ <code>Object</code>
 Generates all needed parameters (including signature) for requesting Silkey SSO
 
 **Kind**: static method of [<code>SilkeySDK</code>](#module_SilkeySDK)  
+**Throws**:
+
+- on missing required data
+
 
 | Param | Type | Description |
 | --- | --- | --- |
 | privateKey | <code>string</code> | this should be private key of domain owner |
-| data | <code>Object</code> | Object with data: {redirectUrl*, redirectMethod, cancelUrl*, refId, scope, ssoTimestamp*}  marked with * are required by Silkey SSO |
+| params | <code>Object</code> | Object with data: {redirectUrl*, redirectMethod, cancelUrl*, refId, scope, ssoTimestamp}  marked with * are required by Silkey SSO |
 
 **Example**  
 ```js

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![Silkey Logo](https://raw.githubusercontent.com/Silkey-Team/brand/master/silkey-word-black.png)
-
 # Silkey SDK for NodeJS
+
+![Silkey Logo](https://raw.githubusercontent.com/Silkey-Team/brand/master/silkey-word-black.png)
 
 [![GitHub version](https://badge.fury.io/gh/Silkey-Team%2Fsilkey-sdk.svg)](https://badge.fury.io/gh/Silkey-Team%2Fsilkey-sdk)
 [![npm version](https://badge.fury.io/js/%40silkey%2Fsdk.svg)](https://badge.fury.io/js/%40silkey%2Fsdk)
@@ -25,8 +25,8 @@ Redirect user to Silkey with parameters:
 | signature        | yes       | string   | Domain owner signature
 | ssoTimestamp     | yes       | number   | Time of signing SSO request
 | redirectUrl      | yes       | string   | Where to redirect user with token after sign in
-| redirectMethod   | no        | GET/POST | How to redirect user after sign in, default is POST
 | cancelUrl        | yes       | string   | Where to redirect user on error
+| redirectMethod   | no        | GET/POST | How to redirect user after sign in, default is POST
 | refId            | no        | string   | It will be return with user token, you may use it to identify request
 | scope            | no        | string   | Scope of data to return in a token payload: `id` (default) returns only user address, `email` returns address + email
 
@@ -82,9 +82,6 @@ The Production
     - Create an account for the application
     - Click on account details then export private key to view and write down the private key
     
-    A very small amount of ether is used to verify that the domain is registered.
-    To obtain free ether on the Rinkeby test network visit https://faucet.rinkeby.io/
-    
 1. Authenticate the domain of the application in Apollo with the generated wallet:
 
    Visit the propper Apollo url (see above), there is a wizzard that will guide you through all this steps:
@@ -96,6 +93,9 @@ The Production
     - Add logo url that will be displayed when a user is loging in using silkey
     - Send a transaction which will save the registration
 
+    Some amount of ether is used to send transaction to blockchain.
+    To obtain free ether on the Sandbox (Rinkeby test network) visit https://faucet.rinkeby.io/
+    
 3.  Export private key from MetaMask and store it in a secure way inside your application. You will need it to generate the request for *Silkey Sing In*.
 
 #### On SignIn page

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silkey/sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "SDK for Sign In with Silke",
   "main": "src/index.js",
   "type": "module",
@@ -12,6 +12,7 @@
     "test": "mocha test",
     "test:one": "mocha ",
     "doc": "jsdoc2md src/sso.js > DOCS.md",
+    "git:amend": "git commit --amend --no-edit && git push --force",
     "pre-push": "npm run lint && npm run doc && npm run test"
   },
   "repository": {

--- a/test/jwtPayload.test.js
+++ b/test/jwtPayload.test.js
@@ -1,5 +1,6 @@
 import chai from 'chai'
 import { JwtPayload, toJwtPayload } from '../src/models/jwtPayload.js'
+import { expectThrows } from './utils/utils.js'
 
 const { expect, assert } = chai
 
@@ -97,13 +98,13 @@ describe('validate()', async () => {
 
     it('throws when required data present', () => {
       const payload = new JwtPayload()
-      assert.throws(() => payload.validate(), Error)
+      expectThrows(() => payload.validate(), Error, 'address is invalid: ')
 
       payload.setScope('id')
-      assert.throws(() => payload.validate(), Error)
+      expectThrows(() => payload.validate(), Error, 'address is invalid: ')
 
       payload.setAddress(address)
-      assert.throws(() => payload.validate(), Error)
+      expectThrows(() => payload.validate(), Error, 'userSignature is invalid: ')
 
       payload.setUserSignature('0'.repeat(130), currentTimestamp)
       assert.doesNotThrow(() => payload.validate())
@@ -123,19 +124,19 @@ describe('validate()', async () => {
 
     it('throws when required data present', () => {
       const payload = new JwtPayload()
-      assert.throws(() => payload.validate(), Error)
+      expectThrows(() => payload.validate(), Error, 'address is invalid: ')
 
       payload.setScope('email')
-      assert.throws(() => payload.validate(), Error)
+      expectThrows(() => payload.validate(), Error, 'address is invalid: ')
 
       payload.setAddress(address)
-      assert.throws(() => payload.validate(), Error)
+      expectThrows(() => payload.validate(), Error, 'userSignature is invalid: ')
 
       payload.setUserSignature('0'.repeat(130), currentTimestamp)
-      assert.throws(() => payload.validate(), Error)
+      expectThrows(() => payload.validate(), Error, 'email is invalid: ')
 
       payload.setEmail('a@b')
-      assert.throws(() => payload.validate(), Error)
+      expectThrows(() => payload.validate(), Error, 'silkeySignature is invalid: ')
 
       payload.setSilkeySignature('0'.repeat(130), currentTimestamp)
       assert.doesNotThrow(() => payload.validate())

--- a/test/sso.test.js
+++ b/test/sso.test.js
@@ -3,6 +3,7 @@ import chai from 'chai'
 
 import { privateKey } from './keys.js'
 import { fetchSilkeyPublicKey, generateSSORequestParams, messageToSign } from '../src/sso.js'
+import { expectThrowsAsync } from './utils/utils.js'
 
 dotenv.config()
 
@@ -18,28 +19,52 @@ describe('sso.js', () => {
     })
 
     it('generates message with data', () => {
-      const m = messageToSign({
-        b: 2,
-        a: 1
-      })
-      expect(m).to.eq('a=1::b=2')
+      expect(messageToSign({ b: 2, a: 1 })).to.eq('a=1&b=2')
+      expect(messageToSign({ d: null, c: '', b: 2, a: 1 })).to.eq('a=1&b=2&c=')
     })
   })
 
   describe('generateSSORequestParams()', () => {
-    it('throws when PK is not provided', async () => {
-      await expect(generateSSORequestParams()).to.throws
-    })
+    describe('throws when', () => {
+      it('PK is not provided', async () => {
+        await expectThrowsAsync(() => generateSSORequestParams(), Error, '`privateKey` is required')
+      })
 
-    it('throws when PK is not valid', async () => {
-      await expect(generateSSORequestParams('0x123')).to.throws
+      it('PK is not valid', async () => {
+        await expectThrowsAsync(() => generateSSORequestParams('0x123'), Error, '`redirectUrl` is required')
+      })
+
+      it('missing required parameters', async () => {
+        await expectThrowsAsync(() => generateSSORequestParams(privateKey, {}), Error, '`redirectUrl` is required')
+
+        await expectThrowsAsync(
+          () => generateSSORequestParams(privateKey, { redirectUrl: 'redirectUrl' }),
+          Error, '`cancelUrl` is required'
+        )
+      })
     })
 
     it('generates signature for SSO request', async () => {
-      const { signature, ssoTimestamp } = await generateSSORequestParams(privateKey, { ssoTimestamp: 1602151787, redirectUrl: 'http', cancelUrl: 'http' })
+      const data = { ssoTimestamp: 1602151787, redirectUrl: 'http', cancelUrl: 'http' }
+      const params = await generateSSORequestParams(privateKey, data)
+      const sig = '0xb60f9b1f5c9d6e58b5d802a5019f96415ab7b14bea45721d74e0868df48c85080063beffb19a485b0038b1b158c31ddab4dff08458b0d9a9a43da0b3a2abb72b1b'
 
-      expect(signature).to.eq('0x225883a83c013f87f69c5ec45c1e1644562a261c194b2752458b6001d282dbbf60e95f5f335e84cbfc0ef8cf58d15d77cf73d124bc0c1791f0ab61a0b7e48aa31b')
-      expect(ssoTimestamp).to.eq(1602151787)
+      expect(params.signature).to.eq(sig)
+      expect(params.ssoTimestamp).to.eq(1602151787)
+
+      data.unset = null
+      const paramsWithUnset = await generateSSORequestParams(privateKey, data)
+
+      expect(paramsWithUnset.signature).to.eq(params.signature)
+      expect(paramsWithUnset.ssoTimestamp).to.eq(params.ssoTimestamp)
+      console.log(data)
+
+      data.unset = ''
+      const paramsWithSet = await generateSSORequestParams(privateKey, data)
+
+      console.log(data)
+      expect(paramsWithSet.signature).not.to.eq(params.signature)
+      expect(paramsWithSet.ssoTimestamp).to.eq(params.ssoTimestamp)
     })
 
     it('sets timestamp when not provided', async () => {
@@ -57,30 +82,25 @@ describe('sso.js', () => {
     })
 
     it('generates same signature for null/empty data', async () => {
-      const { signature } = await generateSSORequestParams(privateKey, {
+      const data1 = await generateSSORequestParams(privateKey, {
         timestamp: 1,
         redirectUrl: 'http',
         cancelUrl: 'http',
-        refId: '',
-        scope: ''
+        scope: 'id',
+        refId: null
       })
+
       const data2 = await generateSSORequestParams(privateKey, {
         timestamp: 1,
         redirectUrl: 'http',
         cancelUrl: 'http',
-        refId: null,
-        scope: null
-      })
-      const data3 = await generateSSORequestParams(privateKey, {
-        timestamp: 1,
-        redirectUrl: 'http',
-        cancelUrl: 'http',
         refId: undefined,
-        scope: undefined
+        scope: undefined,
+        a: null,
+        b: undefined
       })
 
-      expect(signature).to.eq(data2.signature)
-      expect(signature).to.eq(data3.signature)
+      expect(data1.signature).to.eq(data2.signature)
     })
 
     it('generates same signature for same data', async () => {
@@ -103,10 +123,17 @@ describe('sso.js', () => {
   })
 
   describe('fetchSilkeyPublicKey()', () => {
-    it('expect to fetch silkey public key', async () => {
-      const m = await fetchSilkeyPublicKey(process.env.PROVIDER_URI, '0xcEf09Bdb5d73055bc52C55E81F1138f48bcc0eCc')
-      expect(m).not.to.eq('0x0000000000000000000000000000000000000000')
-      expect(m.length).to.eq(42)
-    })
+    const { PROVIDER_URI } = process.env
+
+    it('expect to fetch silkey public key', (done) => {
+      if (PROVIDER_URI) {
+        fetchSilkeyPublicKey(PROVIDER_URI, '0xcEf09Bdb5d73055bc52C55E81F1138f48bcc0eCc')
+          .then(m => {
+            expect(m).not.to.eq('0x0000000000000000000000000000000000000000')
+            expect(m.length).to.eq(42)
+            done()
+          })
+      }
+    }).timeout(5000)
   })
 })

--- a/test/utils/utils.js
+++ b/test/utils/utils.js
@@ -1,0 +1,63 @@
+import chai from 'chai'
+
+const { expect } = chai
+
+export const expectThrows = (method, errorType, errorMessage) => {
+  let error = null
+  let msg = null
+
+  try {
+    method()
+    msg = 'Expect method to throw'
+
+    if (errorMessage) {
+      msg += ` with message: ${errorMessage}`
+    }
+  } catch (err) {
+    error = err
+  }
+
+  if (!error) {
+    throw Error(msg)
+  }
+
+  expect(error).to.be.an.instanceOf(errorType)
+
+  if (errorMessage) {
+    expect(error.message).to.equal(errorMessage)
+  }
+}
+
+export const expectThrowsAsync = async (method, errorType, errorMessage) => {
+  let error = null
+  let msg = null
+
+  try {
+    await method()
+    msg = 'Expect method to throw'
+
+    if (errorMessage) {
+      msg += ` with message: ${errorMessage}`
+    }
+  } catch (err) {
+    error = err
+  }
+
+  if (!error) {
+    throw Error(msg)
+  }
+
+  expect(error).to.be.an.instanceOf(errorType)
+
+  if (errorMessage) {
+    expect(error.message).to.equal(errorMessage)
+  }
+}
+
+export const expectNotToThrowsAsync = async method => {
+  try {
+    await method()
+  } catch (err) {
+    throw Error(err.message)
+  }
+}


### PR DESCRIPTION
- `generateSSORequestParams` throws on empty PK
- join operator for `messageeToSign` is now `&`
- ensure testing `throws` is working correctly