### PR TITLE
Change token verifier to not include verifySilkeySignature

### DIFF
--- a/src/services/sso.ts
+++ b/src/services/sso.ts
@@ -139,10 +139,6 @@ export const tokenPayloadVerifier = (
       return null
     }
 
-    if (Verifier.verifySilkeySignature(jwtPayload, silkeyEthAddress) === false) {
-      return null
-    }
-
     if (!Verifier.verifyWebsiteSignature(ssoParams, websiteOwnerAddress)) {
       return null
     }

--- a/test/services/sso.test.ts
+++ b/test/services/sso.test.ts
@@ -185,7 +185,7 @@ describe('sso', () => {
     it('validates token for scope ID and returns payload', () => {
       const payload = tokenPayloadVerifier(validScopeIdToken, callbackParamsForId, webPublicKey, publicKey, 0)
       expect(payload).not.to.be.null
-      expect(payload?.address).not.to.undefined
+      expect(payload!.address).not.to.undefined
     })
 
     it('validates token for scope:email and returns payload', () => {


### PR DESCRIPTION
verifySilkeySignature was removed because it verifies the emailValidation
proof and timestamp, which no longer exist on the account and are not
included in the token.